### PR TITLE
External shutdown hooks for gateway and hub.

### DIFF
--- a/rocon_gateway/package.xml
+++ b/rocon_gateway/package.xml
@@ -27,6 +27,7 @@
   <run_depend>rosservice</run_depend>
   <run_depend>zeroconf_msgs</run_depend>
   <run_depend>gateway_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
   <!-- 
     Don't hardcode a dependency to a particular platform's zeroconf implementation 
     even if it does appeal to us ubuntu eggheads.

--- a/rocon_gateway/scripts/gateway.py
+++ b/rocon_gateway/scripts/gateway.py
@@ -20,4 +20,3 @@ if __name__ == '__main__':
     rospy.init_node('gateway')
     gateway = GatewayNode()
     gateway.spin()
-    gateway.shutdown()

--- a/rocon_gateway/src/rocon_gateway/gateway_hub.py
+++ b/rocon_gateway/src/rocon_gateway/gateway_hub.py
@@ -117,7 +117,7 @@ class GatewayHub(rocon_hub_client.Hub):
           @param firewall
           @param unique_gateway_name
           @param remote_gateway_request_callbacks
-          @param hub_connection_lost_hook : used to trigger Gateway.disengage_hub(hub) on lost hub connections in redis pubsub listener thread.
+          @param hub_connection_lost_gateway_hook : used to trigger Gateway.disengage_hub(hub) on lost hub connections in redis pubsub listener thread.
           @gateway_ip
 
           @raise HubConnectionLostError if for some reason, the redis server has become unavailable.

--- a/rocon_gateway/src/rocon_gateway/ros_parameters.py
+++ b/rocon_gateway/src/rocon_gateway/ros_parameters.py
@@ -57,7 +57,13 @@ def setup_ros_parameters():
     # Network interface name (to be used when there are multiple active interfaces))
     param['network_interface'] = rospy.get_param('~network_interface', '')  # string
 
+    # Let an external party (e.g. concert conductor) manually shutdown the gateway
+    # so we can have control over when flips and pulls get deregistered (lets us do last
+    # minute service calls across masters before our own master goes down)
+    param['external_shutdown'] = rospy.get_param('~external_shutdown', False)
+
     return param
+
 
 def generate_rules(param):
     '''

--- a/rocon_hub/launch/hub.launch
+++ b/rocon_hub/launch/hub.launch
@@ -6,10 +6,13 @@
   <arg name="hub_name" default="Rocon Hub" />
   <arg name="hub_port" default="6380" />
   <arg name="zeroconf" default="true" />
-  <node pkg="rocon_hub" type="hub.py" name="gateway_hub">
+  <!-- useful if you want to do stuff before shutting down the hub in ros' shutdown hooks -->
+  <arg name="external_shutdown" default="false" />
+  <node pkg="rocon_hub" type="hub.py" name="hub">
     <rosparam command="load" file="$(find rocon_hub)/param/default.yaml" />
     <param name="name" value="$(arg hub_name)" />
     <param name="port" value="$(arg hub_port)" />
     <param name="zeroconf" value="$(arg zeroconf)" />
+    <param name="external_shutdown" value="$(arg external_shutdown)" />
   </node>
 </launch>

--- a/rocon_hub/package.xml
+++ b/rocon_hub/package.xml
@@ -22,6 +22,7 @@
   <run_depend>avahi-utils</run_depend>
   <run_depend>redis</run_depend>
   <run_depend>redis-server</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>rocon_gateway</run_depend>
   <run_depend>rocon_utilities</run_depend>
 

--- a/rocon_hub/src/rocon_hub/main.py
+++ b/rocon_hub/src/rocon_hub/main.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python
 #
 # License: BSD
-#   https://raw.github.com/robotics-in-concert/rocon_multimaster/master/multimaster_server/rocon_hub/LICENSE
+#   https://raw.github.com/robotics-in-concert/rocon_multimaster/license/LICENSE
 #
+##############################################################################
+# Imports
+##############################################################################
 
 import sys
+import signal
 
 # Ros imports
 import rospy
+import std_srvs.srv as std_srvs
 
 # Local imports
 from . import utils
@@ -17,12 +22,58 @@ from . import watcher
 from . import zeroconf
 
 ##############################################################################
+# Variables
+##############################################################################
+
+redi = None
+
+##############################################################################
+# Shutdown Handlers
+##############################################################################
+#
+# This lets the hub have a controlled shutdown from an external party
+# (in our special case of interest, from the conductor).
+
+
+def ros_service_shutdown(unused_request):
+    shutdown()
+    return std_srvs.EmptyResponse()
+
+
+def shutdown():
+    global redi
+    if redi is not None:
+        rospy.loginfo("Hub : shutting down.")
+        redi.shutdown()
+        redi = None
+
+
+def wait_for_shutdown():
+    '''
+      Shutdown hook - we wait here for an external shutdown via ros service
+      (at which point redi is None)
+      timing out after a reasonable time if we need to.
+    '''
+    global redi
+    timeout = 2.0
+    count = 0.0
+    while count < timeout:
+        if redi is None:
+            return
+        else:
+            count += 0.5
+            rospy.rostime.wallsleep(0.5)  # human time
+    rospy.logwarn("Hub : timed out waiting for external shutdown by ros service, forcing shutdown now.")
+    shutdown()
+
+
+##############################################################################
 # Main
 ##############################################################################
 
 
 def main():
-    # Ros
+    global redi
     while not utils.check_master():
         rospy.logerr("Unable to communicate with master!")
         rospy.rostime.wallsleep(1.0)
@@ -35,6 +86,9 @@ def main():
     utils.check_if_executable_available('redis-server')
     if param['zeroconf']:
         utils.check_if_executable_available('avahi-daemon')
+    if param['external_shutdown']:
+        rospy.on_shutdown(wait_for_shutdown)
+        unused_shutdown_service = rospy.Service('~shutdown', std_srvs.Empty, ros_service_shutdown)
 
     redi = redis_server.RedisServer(param)
     redi.start()  # sys exits if server connection is unavailable
@@ -44,6 +98,7 @@ def main():
 
     watcher_thread = watcher.WatcherThread('localhost', param['port'])
     watcher_thread.start()
-
     rospy.spin()
-    redi.shutdown()
+    if not param['external_shutdown']:
+        # do it here, don't wait for the ros service to get triggered
+        shutdown()

--- a/rocon_hub/src/rocon_hub/ros_parameters.py
+++ b/rocon_hub/src/rocon_hub/ros_parameters.py
@@ -26,5 +26,6 @@ def load():
     param['port'] = rospy.get_param('~port', '6380')
     param['zeroconf'] = rospy.get_param("~zeroconf", True)
     param['max_memory'] = rospy.get_param('~max_memory', '10mb')
+    param['external_shutdown'] = rospy.get_param('~external_shutdown', False)
 
     return param

--- a/rocon_hub_client/src/rocon_hub_client/hub_discovery.py
+++ b/rocon_hub_client/src/rocon_hub_client/hub_discovery.py
@@ -146,6 +146,12 @@ class HubDiscovery(threading.Thread):
         except (rospy.service.ServiceException, rospy.exceptions.ROSInterruptException):
             # means we've shut down, just return so it can cleanly shutdown back in run()
             return [], []
+        except (rospy.exceptions.TransportTerminated):
+            # I'm guessing we should never ever see this - should always be wrapped up
+            # in the above exceptions, but the reality is it does leak through on
+            # shutdown periods. Haven't investigated a fix, but just handle it here for now.
+            # means we've shut down, just return so it can cleanly shutdown back in run()
+            return [], []
         difference = lambda l1, l2: [x for x in l1 if x not in l2]
         new_services = difference(response.services, self._zeroconf_discovered_hubs)
         lost_services = difference(self._zeroconf_discovered_hubs, response.services)

--- a/rocon_utilities/src/rocon_utilities/__init__.py
+++ b/rocon_utilities/src/rocon_utilities/__init__.py
@@ -11,3 +11,4 @@ from ros_utilities import SubscriberProxy, find_resource, find_resource_from_str
 from exceptions import TimeoutExpiredError
 from icons import icon_to_msg, icon_resource_to_msg
 from wall_rate import WallRate
+from system import Popen


### PR DESCRIPTION
External shutdown hooks into the gateway and hub so the conductor can delay their respective shutdowns.

This is introduced as a non-default behaviour, especially for concerts.

Note: bloody signal handling for subprocesses of a rospy node is a huge pain in the ass.

This is in tandem with https://github.com/robotics-in-concert/rocon_concert/pull/128
