### PR TITLE
flips without pubsubs

### DIFF
--- a/rocon_gateway/package.xml
+++ b/rocon_gateway/package.xml
@@ -18,6 +18,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <run_depend>gateway_msgs</run_depend>
+  <run_depend>python-crypto</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>rocon_hub_client</run_depend>
   <run_depend>rocon_console</run_depend>
@@ -29,9 +31,8 @@
   <run_depend>roslib</run_depend>
   <run_depend>rostopic</run_depend>
   <run_depend>rosservice</run_depend>
-  <run_depend>zeroconf_msgs</run_depend>
-  <run_depend>gateway_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
+  <run_depend>zeroconf_msgs</run_depend>
   <!-- 
     Don't hardcode a dependency to a particular platform's zeroconf implementation 
     even if it does appeal to us ubuntu eggheads.

--- a/rocon_gateway/scripts/gateway_info
+++ b/rocon_gateway/scripts/gateway_info
@@ -100,13 +100,14 @@ if __name__ == '__main__':
         print("       : -")
     for remote_rule in gateway.flipped_connections:
         print("       : "),
-        console.pretty_print(remote_rule.gateway, console.red)
+        console.pretty_print(remote_rule.remote_rule.gateway, console.red)
         print("-"),
-        console.pretty_print(remote_rule.rule.name, console.green)
+        console.pretty_print(remote_rule.remote_rule.rule.name, console.green)
         print("-"),
-        console.pretty_print(remote_rule.rule.type, console.cyan)
+        console.pretty_print(remote_rule.remote_rule.rule.type, console.cyan)
         print("-"),
-        console.pretty_print(remote_rule.rule.node + "\n", console.yellow)
+        console.pretty_print(remote_rule.remote_rule.rule.node, console.yellow)
+        print(" [" + remote_rule.status + "]")
 
     print("  Flipped in Connections")
     if len(gateway.flipped_in_connections) == 0:

--- a/rocon_gateway/src/rocon_gateway/gateway.py
+++ b/rocon_gateway/src/rocon_gateway/gateway.py
@@ -147,6 +147,18 @@ class Gateway(object):
                         # This hub was used to send the original flip request
                         hub.remove_flip_details(flip.gateway, flip.rule.name, flip.rule.type, flip.rule.node)
                         break
+
+        # Update flip status
+        flipped_connections = self.flipped_interface.get_flipped_connections()
+        for flip in flipped_connections:
+            for hub in remote_gateway_hub_index[flip.remote_rule.gateway]:
+                status = hub.get_flip_request_status(flip.remote_rule.gateway, flip.remote_rule.rule) 
+                if status is not None:
+                    self.flipped_interface.update_flip_status(flip.remote_rule, status)
+                    # TODO state may not have changed
+                    state_changed = True
+                    break
+                    
         if state_changed:
             self._publish_gateway_info()
 

--- a/rocon_gateway/src/rocon_gateway/gateway.py
+++ b/rocon_gateway/src/rocon_gateway/gateway.py
@@ -154,9 +154,8 @@ class Gateway(object):
             for hub in remote_gateway_hub_index[flip.remote_rule.gateway]:
                 status = hub.get_flip_request_status(flip.remote_rule.gateway, flip.remote_rule.rule) 
                 if status is not None:
-                    self.flipped_interface.update_flip_status(flip.remote_rule, status)
-                    # TODO state may not have changed
-                    state_changed = True
+                    flip_state_changed = self.flipped_interface.update_flip_status(flip.remote_rule, status)
+                    state_changed = state_changed or flip_state_changed
                     break
                     
         if state_changed:

--- a/rocon_gateway/src/rocon_gateway/gateway.py
+++ b/rocon_gateway/src/rocon_gateway/gateway.py
@@ -279,7 +279,8 @@ class Gateway(object):
             for local_registration in local_registrations[connection_type]:
                 matched_registration = None
                 for registration in registrations:
-                    if registration == local_registration:
+                    if registration.connection == local_registration.connection and \
+                       registration.remote_gateway == local_registration.remote_gateway:
                         matched_registration = registration
                         break
                     else:

--- a/rocon_gateway/src/rocon_gateway/gateway_hub.py
+++ b/rocon_gateway/src/rocon_gateway/gateway_hub.py
@@ -712,7 +712,6 @@ class GatewayHub(rocon_hub_client.Hub):
         # Send data
         serialized_data = utils.serialize_connection_request(
             FlipStatus.PENDING, source, encrypted_connection)
-        #TODO remove existing request if present
         self._redis_server.sadd(key, serialized_data)
         return True
 

--- a/rocon_gateway/src/rocon_gateway/gateway_hub.py
+++ b/rocon_gateway/src/rocon_gateway/gateway_hub.py
@@ -640,7 +640,7 @@ class GatewayHub(rocon_hub_client.Hub):
             return True
         return False
 
-    def get_flip_request_status(self, remote_gateway, rule):
+    def get_flip_request_status(self, remote_gateway, rule, source_gateway=None):
         '''
           Get the status of a flipped registration. If the flip request does not
           exist (for instance, in the case where this hub was not used to send
@@ -649,11 +649,13 @@ class GatewayHub(rocon_hub_client.Hub):
           @return the flip status or None
           @rtype same as gateway_msgs.msg.RemoteRuleWithStatus.status or None 
         '''
+        if source_gateway == None:
+            source_gateway = self._unique_gateway_name
         key = hub_api.create_rocon_gateway_key(remote_gateway, 'flip_ins')
         encoded_flips = self._redis_server.smembers(key)
         for flip in encoded_flips:
             cmd, source, connection_list = utils.deserialize_request(flip)
-            if source != self._unique_gateway_name:
+            if source != source_gateway:
                 continue
             connection = utils.get_connection_from_list(connection_list)
             # Compare rules as xmlrpc_uri and type_info are encrypted

--- a/rocon_gateway/src/rocon_gateway/gateway_hub.py
+++ b/rocon_gateway/src/rocon_gateway/gateway_hub.py
@@ -55,64 +55,9 @@ class HubConnectionCheckerThread(threading.Thread):
             rate.sleep()
         self._hub_connection_lost_hook()
 
-###############################################################################
-# Redis Callback Handler
-##############################################################################
-
-
-class RedisListenerThread(threading.Thread):
-    '''
-      Tunes into the redis channels that have been subscribed to and
-      calls the apropriate callbacks.
-    '''
-    def __init__(self, redis_pubsub_server, remote_gateway_request_callbacks, hub_connection_lost_hook):
-        threading.Thread.__init__(self)
-        self.daemon = True  # clean shut down of thread when hub connection is lost
-        self._redis_pubsub_server = redis_pubsub_server
-        self._remote_gateway_request_callbacks = remote_gateway_request_callbacks
-        self._hub_connection_lost_hook = hub_connection_lost_hook
-
-    def run(self):
-        '''
-          Used as a callback for incoming requests on redis pubsub channels.
-
-          The received argument is a list of strings for 'flip':
-
-            - [0] - command : this one is 'flip'
-            - [1] - remote_gateway : the name of the gateway that is flipping to us
-            - [2] - remote_name
-            - [3] - remote_node
-            - [4] - type : one of ConnectionType.PUBLISHER etc
-            - [5] - type_info : a ros format type (e.g. std_msgs/String or service api)
-            - [6] - xmlrpc_uri : the xmlrpc node uri
-
-          The command 'unflip' is the same, not including args 5 and 6.
-        '''
-        try:
-            # This is a generator so it will keep spitting out (alt. to having a while loop here)
-            for r in self._redis_pubsub_server.listen():
-                if r['type'] != 'unsubscribe' and r['type'] != 'subscribe':
-                    command, source, contents = utils.deserialize_request(r['data'])
-                    rospy.logdebug("Gateway : redis listener received a channel publication from %s : [%s]" % (source, command))
-                    if command == 'flip':
-                        registration = utils.Registration(utils.get_connection_from_list(contents), source)
-                        self._remote_gateway_request_callbacks['flip'](registration)
-                    elif command == 'unflip':
-                        self._remote_gateway_request_callbacks['unflip'](utils.get_rule_from_list(contents), source)
-                    else:
-                        rospy.logerr("Gateway : received an unknown command from the hub.")
-        except redis.exceptions.ConnectionError as unused_e:
-            # If we ever start using socket timeouts, we need to distinguish between
-            # timeouts here and actual conenction errors. Unfortunately we only have
-            # strings to do that:
-            #    "Error while reading from socket: ('timed out',)"
-            #    "Socket closed on remote end":
-            self._hub_connection_lost_hook()
-
 ##############################################################################
 # Hub
 ##############################################################################
-
 
 class GatewayHub(rocon_hub_client.Hub):
 
@@ -143,13 +88,12 @@ class GatewayHub(rocon_hub_client.Hub):
     # Hub Connections
     ##########################################################################
 
-    def register_gateway(self, firewall, unique_gateway_name, remote_gateway_request_callbacks, hub_connection_lost_gateway_hook, gateway_ip):
+    def register_gateway(self, firewall, unique_gateway_name, hub_connection_lost_gateway_hook, gateway_ip):
         '''
           Register a gateway with the hub.
 
           @param firewall
           @param unique_gateway_name
-          @param remote_gateway_request_callbacks
           @param hub_connection_lost_gateway_hook : used to trigger Gateway.disengage_hub(hub) on lost hub connections in redis pubsub listener thread.
           @gateway_ip
 
@@ -161,7 +105,6 @@ class GatewayHub(rocon_hub_client.Hub):
         self._redis_keys['gateway'] = hub_api.create_rocon_key(unique_gateway_name)
         self._redis_keys['firewall'] = hub_api.create_rocon_gateway_key(unique_gateway_name, 'firewall')
         self._firewall = 1 if firewall else 0
-        self._remote_gateway_request_callbacks = remote_gateway_request_callbacks
         self._hub_connection_lost_gateway_hook = hub_connection_lost_gateway_hook
         if not self._redis_server.sadd(self._redis_keys['gatewaylist'], self._redis_keys['gateway']):
             # should never get here - unique should be unique
@@ -172,10 +115,6 @@ class GatewayHub(rocon_hub_client.Hub):
         # I think we just used this for debugging, but we might want to hide it in future (it's the ros master hostname/ip)
         self._redis_keys['ip'] = hub_api.create_rocon_gateway_key(unique_gateway_name, 'ip')
         self._redis_server.set(self._redis_keys['ip'], gateway_ip)
-        self._redis_channels['gateway'] = self._redis_keys['gateway']
-        self._redis_pubsub_server.subscribe(self._redis_channels['gateway'])
-        self.remote_gateway_listener_thread = RedisListenerThread(self._redis_pubsub_server, self._remote_gateway_request_callbacks, self._hub_connection_lost_hook)
-        self.remote_gateway_listener_thread.start()
         self.hub_connection_checker_thread = HubConnectionCheckerThread(self.ip, self.port, self._hub_connection_lost_hook)
         self.hub_connection_checker_thread.start()
         self.connection_lost_lock = threading.Lock()
@@ -187,7 +126,7 @@ class GatewayHub(rocon_hub_client.Hub):
 
     def _hub_connection_lost_hook(self):
         '''
-          This gets triggered by the redis pubsub listener when the hub connection is lost.
+          This gets triggered by the redis connection checker thread when the hub connection is lost.
           The trigger is passed to the gateway who needs to remove the hub.
         '''
         self.connection_lost_lock.acquire()
@@ -206,9 +145,7 @@ class GatewayHub(rocon_hub_client.Hub):
           @rtype: bool
         '''
         try:
-            self._redis_pubsub_server.unsubscribe()
             self.unregister_named_gateway(self._redis_keys['gateway'])
-            self._redis_channels = {}
         except (redis.exceptions.ConnectionError, redis.exceptions.ResponseError):
             # usually just means the hub has gone down just before us or is in the
             # middle of doing so let it die nice and peacefully
@@ -629,8 +566,42 @@ class GatewayHub(rocon_hub_client.Hub):
         self._redis_server.srem(key, serialized_data)
 
     ##########################################################################
-    # Gateway-Gateway Communications
+    # Flip specific communication
     ##########################################################################
+
+    def get_unblocked_flipped_in_connections(self):
+        registrations = []
+        key = hub_api.create_rocon_gateway_key(self._unique_gateway_name, 'flip_ins')
+        encoded_flip_ins = []
+        try:
+            encoded_flip_ins = self._redis_server.smembers(key)
+        except (redis.ConnectionError, AttributeError) as unused_e:
+            # probably disconnected from the hub
+            pass
+        for flip_in in encoded_flip_ins:
+            cmd, source, connection_list = utils.deserialize_request(flip_in)
+            connection = utils.get_connection_from_list(connection_list)
+            if cmd != 'block':
+                registrations.append(utils.Registration(connection, source))
+        return registrations
+
+    def block_flip_request(self, registration):
+        self._update_flip_request_status(registration, 'block')
+
+    def accept_flip_request(self, registration):
+        self._update_flip_request_status(registration, 'active')
+
+    def _update_flip_request_status(self, registration, status):
+        key = hub_api.create_rocon_gateway_key(self._unique_gateway_name, 'flip_ins')
+        encoded_flip_ins = self._redis_server.smembers(key)
+        for flip_in in encoded_flip_ins:
+            cmd, source, connection_list = utils.deserialize_request(flip_in)
+            connection = utils.get_connection_from_list(connection_list)
+            if source == registration.remote_gateway and \
+               connection == registration.connection:
+                self._redis_server.srem(key, flip_in)
+        serialized_data = utils.serialize_connection_request(status, registration.remote_gateway, registration.connection)
+        self._redis_server.sadd(key, serialized_data)
 
     def send_flip_request(self, remote_gateway, connection):
         '''
@@ -659,12 +630,11 @@ class GatewayHub(rocon_hub_client.Hub):
           @param xmlrpc_uri : the node uri
           @param str
         '''
+        key = hub_api.create_rocon_gateway_key(remote_gateway, 'flip_ins')
         source = hub_api.key_base_name(self._redis_keys['gateway'])
-        cmd = utils.serialize_connection_request('flip', source, connection)
-        try:
-            self._redis_server.publish(hub_api.create_rocon_key(remote_gateway), cmd)
-        except Exception as unused_e:
-            return False
+        serialized_data = utils.serialize_connection_request('new', source, connection)
+        #TODO remove existing request if present
+        self._redis_server.sadd(key, serialized_data)
         return True
 
     def send_unflip_request(self, remote_gateway, rule):
@@ -700,10 +670,13 @@ class GatewayHub(rocon_hub_client.Hub):
             self._send_unflip_request(remote_gateway, rule)
 
     def _send_unflip_request(self, remote_gateway, rule):
-        source = hub_api.key_base_name(self._redis_keys['gateway'])
-        cmd = utils.serialize_rule_request('unflip', source, rule)
-        try:
-            self._redis_server.publish(hub_api.create_rocon_key(remote_gateway), cmd)
-        except Exception as unused_e:
-            return False
-        return True
+        key = hub_api.create_rocon_gateway_key(remote_gateway, 'flip_ins')
+        encoded_flip_ins = self._redis_server.smembers(key)
+        for flip_in in encoded_flip_ins:
+            cmd, source, connection_list = utils.deserialize_request(flip_in)
+            connection = utils.get_connection_from_list(connection_list)
+            if source == hub_api.key_base_name(self._redis_keys['gateway']) and \
+               rule == connection.rule:
+                self._redis_server.srem(key, flip_in)
+                return True
+        return False

--- a/rocon_gateway/src/rocon_gateway/gateway_node.py
+++ b/rocon_gateway/src/rocon_gateway/gateway_node.py
@@ -135,7 +135,6 @@ class GatewayNode():
                     port,
                     self._param['firewall'],  # Gateway Details
                     self._unique_name,
-                    self._gateway.remote_gateway_request_callbacks,
                     self._disengage_hub,
                     self._gateway.ip,
                     existing_advertisements

--- a/rocon_gateway/src/rocon_gateway/graph.py
+++ b/rocon_gateway/src/rocon_gateway/graph.py
@@ -79,12 +79,12 @@ class Graph(object):
         self.flipped_edges = EdgeList()
         # Check local gateway
         for remote_rule in self._local_gateway.flipped_connections:
-            self.gateway_edges.add(Edge(self._local_gateway.name, remote_rule.gateway))
+            self.gateway_edges.add(Edge(self._local_gateway.name, remote_rule.remote_rule.gateway))
             # this adds a bloody magic space, to help disambiguate node names from topic names
-            connection_id = rosgraph.impl.graph.topic_node(remote_rule.rule.name + '-' + remote_rule.rule.type)
+            connection_id = rosgraph.impl.graph.topic_node(remote_rule.remote_rule.rule.name + '-' + remote_rule.remote_rule.rule.type)
             self.flipped_nodes.append(connection_id)
             self.flipped_edges.add(Edge(self._local_gateway.name, connection_id))
-            self.flipped_edges.add(Edge(connection_id, remote_rule.gateway))
+            self.flipped_edges.add(Edge(connection_id, remote_rule.remote_rule.gateway))
         for remote_rule in self._local_gateway.pulled_connections:
             connection_id = rosgraph.impl.graph.topic_node(remote_rule.rule.name + '-' + remote_rule.rule.type)
             self.pulled_nodes.append(connection_id)

--- a/rocon_gateway/src/rocon_gateway/hub_manager.py
+++ b/rocon_gateway/src/rocon_gateway/hub_manager.py
@@ -144,8 +144,8 @@ class HubManager(object):
 
     def send_unflip_request(self, remote_gateway_name, remote_rule):
         '''
-          Send an unflip request to the specified gateway through
-          the first common hub that can be found.
+          Send an unflip request to the specified gateway through all available
+          hubs.
 
           Doesn't raise GatewayUnavailableError if nothing got sent as the higher level
           doesn't need any logic there yet (only called from gateway.shutdown).
@@ -159,11 +159,10 @@ class HubManager(object):
         self._hub_lock.acquire()
         for hub in self.hubs:
             if remote_gateway_name in hub.list_remote_gateway_names():
-                # I don't think we need more than one hub's info....
                 try:
-                    hub.send_unflip_request(remote_gateway_name, remote_rule)
-                    self._hub_lock.release()
-                    return
+                    if hub.send_unflip_request(remote_gateway_name, remote_rule):
+                        self._hub_lock.release()
+                        return
                 except GatewayUnavailableError:
                     pass  # cycle through the other hubs looking as well.
         self._hub_lock.release()

--- a/rocon_gateway/src/rocon_gateway/hub_manager.py
+++ b/rocon_gateway/src/rocon_gateway/hub_manager.py
@@ -83,6 +83,20 @@ class HubManager(object):
         self._hub_lock.release()
         return dic
 
+    def get_flip_requests(self):
+        ''' 
+          Returns all unblocked flip requests received by this hub
+
+          @return list of flip registration requests
+          @rtype list of utils.Registration
+        '''
+        registrations = []
+        self._hub_lock.acquire()
+        for hub in self.hubs:
+            registrations.extend(hub.get_unblocked_flipped_in_connections())
+        self._hub_lock.release()
+        return registrations
+
     def remote_gateway_info(self, remote_gateway_name):
         '''
           Return information that a remote gateway has posted on the hub(s).
@@ -163,7 +177,6 @@ class HubManager(object):
                        port,
                        firewall_flag,
                        gateway_unique_name,
-                       remote_gateway_request_callbacks,
                        gateway_disengage_hub,  # hub connection lost hook
                        gateway_ip,
                        existing_advertisements
@@ -204,7 +217,6 @@ class HubManager(object):
             self._hub_lock.acquire()
             new_hub.register_gateway(firewall_flag,
                                      gateway_unique_name,
-                                     remote_gateway_request_callbacks,
                                      gateway_disengage_hub,  # hub connection lost hook
                                      gateway_ip,
                                      )

--- a/rocon_gateway/src/rocon_gateway/utils.py
+++ b/rocon_gateway/src/rocon_gateway/utils.py
@@ -9,7 +9,7 @@
 
 #import collections
 import copy
-import cPickle
+import cPickle as pickle
 #import simplejson as json
 import os
 
@@ -166,11 +166,11 @@ class Registration():
 
 def serialize(data):
     #return json.dumps(data)
-    return cPickle.dumps(data)
+    return pickle.dumps(data)
 
 def deserialize(str_msg):
     #return convert(json.loads(str_msg))
-    return cPickle.loads(str_msg)
+    return pickle.loads(str_msg)
 
 def serialize_connection(connection):
     return serialize([connection.rule.type,

--- a/rocon_gateway/src/rocon_gateway/utils.py
+++ b/rocon_gateway/src/rocon_gateway/utils.py
@@ -238,9 +238,8 @@ def encrypt(plaintext, public_key):
     return plaintext
 
 def decrypt(ciphertext, key):
-    import rospy
-    rospy.loginfo(str(len(ciphertext)) + " : " + ciphertext)
-    return str(key.decrypt(ciphertext))
+    #return key.decrypt(str(ciphertext))
+    return ciphertext
 
 def decrypt_connection(connection, key):
     decrypted_connection = copy.deepcopy(connection)

--- a/rocon_gateway/src/rocon_gateway/utils.py
+++ b/rocon_gateway/src/rocon_gateway/utils.py
@@ -7,8 +7,13 @@
 # Imports
 ##############################################################################
 
-import json
 import collections
+import json
+import os
+
+from Crypto.PublicKey import RSA
+import Crypto.Util.number as CUN
+
 from gateway_msgs.msg import Rule, ConnectionType
 
 ##############################################################################
@@ -208,6 +213,28 @@ def get_connection_from_list(connection_argument_list):
 
 def get_rule_from_list(rule_argument_list):
     return Rule(rule_argument_list[0], rule_argument_list[1], rule_argument_list[2])
+
+##########################################################################
+# Encryption/Decryption 
+##########################################################################
+
+def generate_private_public_key():
+    key = RSA.generate(2048)
+    public_key = key.publickey()
+    return key, public_key
+
+def deserialize_key(str):
+    return RSA.importKey(str) 
+
+def serialize_key(key):
+    return key.exportKey()
+
+def encrypt(str, public_key):
+    K = CUN.getRandomNumber(128, os.urandom) # Not used, legacy compatibility
+    return public_key.encrypt(str, K)
+
+def decrypt(ciphertext, key):
+    return key.decrypt(ciphertext)
 
 ##########################################################################
 # Regex

--- a/rocon_gateway/src/rocon_gateway/utils.py
+++ b/rocon_gateway/src/rocon_gateway/utils.py
@@ -192,7 +192,6 @@ def serialize_connection_request(command, source, connection):
                       connection.xmlrpc_uri]
                      )
 
-
 def serialize_rule_request(command, source, rule):
     return serialize([command, source, rule.type, rule.name, rule.node])
 

--- a/rocon_gateway/src/rocon_gateway/utils.py
+++ b/rocon_gateway/src/rocon_gateway/utils.py
@@ -7,9 +7,10 @@
 # Imports
 ##############################################################################
 
-import collections
+#import collections
 import copy
-import json
+import cPickle
+#import simplejson as json
 import os
 
 from Crypto.PublicKey import RSA
@@ -148,26 +149,28 @@ class Registration():
 ##########################################################################
 
 
-def convert(data):
-    '''
-      Convert unicode to standard string (Not sure how necessary this is)
-      http://stackoverflow.com/questions/1254454/fastest-way-to-convert-a-dicts-keys-values-from-unicode-to-str
-    '''
-    if isinstance(data, unicode):
-        return str(data)
-    elif isinstance(data, collections.Mapping):
-        return dict(map(convert, data.iteritems()))
-    elif isinstance(data, collections.Iterable):
-        return type(data)(map(convert, data))
-    else:
-        return data
-
+# def convert(data):
+#     '''
+#       Convert unicode to standard string (Not sure how necessary this is)
+#       http://stackoverflow.com/questions/1254454/fastest-way-to-convert-a-dicts-keys-values-from-unicode-to-str
+#     '''
+#     if isinstance(data, unicode):
+#         return str(data)
+#     elif isinstance(data, collections.Mapping):
+#         return dict(map(convert, data.iteritems()))
+#     elif isinstance(data, collections.Iterable):
+#         return type(data)(map(convert, data))
+#     else:
+#         return data
+# 
 
 def serialize(data):
-    return json.dumps(data)
+    #return json.dumps(data)
+    return cPickle.dumps(data)
 
 def deserialize(str_msg):
-    return convert(json.loads(str_msg))
+    #return convert(json.loads(str_msg))
+    return cPickle.loads(str_msg)
 
 def serialize_connection(connection):
     return serialize([connection.rule.type,
@@ -234,12 +237,13 @@ def encrypt(plaintext, public_key):
         #TODO need to have arbitrary lengths
         raise ValueError('Trying to encrypt text longer than ' + MAX_PLAINTEXT_LENGTH + ' bytes!')
     K = CUN.getRandomNumber(128, os.urandom) # Not used, legacy compatibility
-    #return unicode(public_key.encrypt(plaintext, K))
-    return plaintext
+    ciphertext = public_key.encrypt(plaintext, K)
+    return ciphertext[0]
+    #return plaintext
 
 def decrypt(ciphertext, key):
-    #return key.decrypt(str(ciphertext))
-    return ciphertext
+    return key.decrypt(ciphertext)
+    #return ciphertext
 
 def decrypt_connection(connection, key):
     decrypted_connection = copy.deepcopy(connection)

--- a/rocon_gateway/src/rocon_gateway/watcher_thread.py
+++ b/rocon_gateway/src/rocon_gateway/watcher_thread.py
@@ -74,6 +74,8 @@ class WatcherThread(object):
                 self._gateway.update_flipped_interface(connections, remote_gateway_hub_index)
                 self._gateway.update_public_interface(connections)
                 self._gateway.update_pulled_interface(connections, remote_gateway_hub_index)
+                registrations = self._hub_manager.get_flip_requests()
+                self._gateway.update_flipped_in_interface(registrations, remote_gateway_hub_index)
             self._sleep()
 
     def _sleep(self):

--- a/rocon_gateway_tests/launch/singlehub/singlehub.concert
+++ b/rocon_gateway_tests/launch/singlehub/singlehub.concert
@@ -1,0 +1,5 @@
+<concert>
+  <launch package="rocon_hub" name="hub.launch" port="11311"/>
+  <launch package="rocon_gateway_tests" name="singlehub_gateway1.launch" port="11312"/>
+  <launch package="rocon_gateway_tests" name="singlehub_gateway2.launch" port="11313"/>
+</concert>

--- a/rocon_gateway_tests/launch/singlehub/singlehub_gateway1.launch
+++ b/rocon_gateway_tests/launch/singlehub/singlehub_gateway1.launch
@@ -1,0 +1,31 @@
+<launch>
+
+  <node ns="zeroconf" pkg="zeroconf_avahi" type="zeroconf" name="zeroconf"/>
+  <node pkg="rocon_gateway" type="gateway.py" name="gateway" output="screen">
+    <rosparam param="name">gateway1</rosparam>
+    <rosparam param="firewall">false</rosparam>
+    <rosparam param="disable_uuids">true</rosparam>
+    <rosparam command="load" file="$(find rocon_gateway_tests)/param/singlehub/gateway1.yaml" />
+  </node>
+
+  <include file="$(find rocon_gateway_tests)/launch/common/talker.xml">
+    <arg name="anonymize" value="true" />
+    <arg name="topic" value="advertised_chatter_from_gateway1" />
+  </include>
+
+  <include file="$(find rocon_gateway_tests)/launch/common/talker.xml">
+    <arg name="anonymize" value="true" />
+    <arg name="topic" value="flipped_chatter_from_gateway1" />
+  </include>
+
+  <include file="$(find rocon_gateway_tests)/launch/common/listener.xml">
+    <arg name="anonymize" value="true" />
+    <arg name="topic" value="advertised_chatter_from_gateway2" />
+  </include>
+
+  <include file="$(find rocon_gateway_tests)/launch/common/listener.xml">
+    <arg name="anonymize" value="true" />
+    <arg name="topic" value="flipped_chatter_from_gateway2" />
+  </include>
+
+</launch>

--- a/rocon_gateway_tests/launch/singlehub/singlehub_gateway2.launch
+++ b/rocon_gateway_tests/launch/singlehub/singlehub_gateway2.launch
@@ -1,0 +1,31 @@
+<launch>
+
+  <node ns="zeroconf" pkg="zeroconf_avahi" type="zeroconf" name="zeroconf"/>
+  <node pkg="rocon_gateway" type="gateway.py" name="gateway" output="screen">
+    <rosparam param="name">gateway2</rosparam>
+    <rosparam param="firewall">false</rosparam>
+    <rosparam param="disable_uuids">true</rosparam>
+    <rosparam command="load" file="$(find rocon_gateway_tests)/param/singlehub/gateway2.yaml" />
+  </node>
+
+  <include file="$(find rocon_gateway_tests)/launch/common/talker.xml">
+    <arg name="anonymize" value="true" />
+    <arg name="topic" value="advertised_chatter_from_gateway2" />
+  </include>
+
+  <include file="$(find rocon_gateway_tests)/launch/common/talker.xml">
+    <arg name="anonymize" value="true" />
+    <arg name="topic" value="flipped_chatter_from_gateway2" />
+  </include>
+
+  <include file="$(find rocon_gateway_tests)/launch/common/listener.xml">
+    <arg name="anonymize" value="true" />
+    <arg name="topic" value="advertised_chatter_from_gateway1" />
+  </include>
+
+  <include file="$(find rocon_gateway_tests)/launch/common/listener.xml">
+    <arg name="anonymize" value="true" />
+    <arg name="topic" value="flipped_chatter_from_gateway1" />
+  </include>
+
+</launch>

--- a/rocon_gateway_tests/param/singlehub/gateway1.yaml
+++ b/rocon_gateway_tests/param/singlehub/gateway1.yaml
@@ -1,0 +1,79 @@
+##############################################################################
+# Core parameters - defaults are commented with a #
+##############################################################################
+
+## Uri for the hub - set this if you want to manually
+## find the gateway hub instead of via zeroconf.
+## Typical setting for a redis server on ubuntu would
+## be: http://gateway1host:6379. We usually start our own
+## redis server, which can usually be found on 6380.
+# hub_uri: 
+
+## Hub whitelist/blacklists - use these to control 
+## which hubs you wish to work with.
+## Hubs are referred to either by ip or hub name. 
+# hub_whitelist: []
+# hub_blacklist: []
+
+## Gateway name - this is a human readable convenience only
+# name: 'gateway'
+
+## Watch loop period - how long the watcher should sleep
+## inbetween checking if system state needs synchronisation
+# watch_loop_period: 10
+
+# Used to block/permit gateway2 gateway's from flipping to this gateway.
+firewall: false
+
+# Make everything (except the default_blacklist) publicly available for pulling
+# advertise_all: false
+
+##############################################################################
+# External parameters
+##############################################################################
+
+# The default blacklist to use for flip_all/pull_all rules
+#   we include default_blacklist.yaml separately for an example 
+
+##############################################################################
+# Example static parameters - defaults for these are always empty
+##############################################################################
+# Note that the pull_all, flip_all default rules negate any 
+# other default rules for the targeted gateways.
+#
+default_advertisements: 
+   - name: /advertised_chatter_from_gateway1
+     node: None
+     type: publisher
+#    - name: /chat.*
+#      node: None
+#      type: subscriber
+#
+default_flips:
+#    - gateway: pirate_.*            # regex can also be used 
+#    - gateway: pirate_gateway       # flip to a specific rule to a gateway
+    - gateway: gateway2              # flip_all to this gateway, blacklist is only the default_blacklist 
+      rule:  
+        name: /flipped_chatter_from_gateway1
+        node: None
+        type: publisher
+#    - gateway: pirate_.*            # regex can be used for the rule too
+#      rule:  
+#        name: /chat.*
+#        node: None
+#        type: subscriber
+#
+default_pulls:
+#    - gateway: pirate_gateway 
+#    - gateway: pirate_.* 
+   - gateway: gateway2
+     rule:  
+       name: /advertised_chatter_from_gateway2
+       node: None
+       type: publisher
+#    - gateway: pirate_.*
+#      rule:  
+#        name: /chat.*
+#        node: None
+#        type: subscriber
+        

--- a/rocon_gateway_tests/param/singlehub/gateway2.yaml
+++ b/rocon_gateway_tests/param/singlehub/gateway2.yaml
@@ -1,0 +1,79 @@
+##############################################################################
+# Core parameters - defaults are commented with a #
+##############################################################################
+
+## Uri for the hub - set this if you want to manually
+## find the gateway hub instead of via zeroconf.
+## Typical setting for a redis server on ubuntu would
+## be: http://gateway1host:6379. We usually start our own
+## redis server, which can usually be found on 6380.
+# hub_uri: 
+
+## Hub whitelist/blacklists - use these to control 
+## which hubs you wish to work with.
+## Hubs are referred to either by ip or hub name. 
+# hub_whitelist: []
+# hub_blacklist: []
+
+## Gateway name - this is a human readable convenience only
+# name: 'gateway'
+
+## Watch loop period - how long the watcher should sleep
+## inbetween checking if system state needs synchronisation
+# watch_loop_period: 10
+
+# Used to block/permit gateway2 gateway's from flipping to this gateway.
+firewall: false
+
+# Make everything (except the default_blacklist) publicly available for pulling
+# advertise_all: false
+
+##############################################################################
+# External parameters
+##############################################################################
+
+# The default blacklist to use for flip_all/pull_all rules
+#   we include default_blacklist.yaml separately for an example 
+
+##############################################################################
+# Example static parameters - defaults for these are always empty
+##############################################################################
+# Note that the pull_all, flip_all default rules negate any 
+# other default rules for the targeted gateways.
+#
+default_advertisements: 
+   - name: /advertised_chatter_from_gateway2
+     node: None
+     type: publisher
+#    - name: /chat.*
+#      node: None
+#      type: subscriber
+#
+default_flips:
+#    - gateway: pirate_.*            # regex can also be used 
+#    - gateway: pirate_gateway       # flip to a specific rule to a gateway
+    - gateway: gateway1              # flip_all to this gateway, blacklist is only the default_blacklist 
+      rule:  
+        name: /flipped_chatter_from_gateway2
+        node: None
+        type: publisher
+#    - gateway: pirate_.*            # regex can be used for the rule too
+#      rule:  
+#        name: /chat.*
+#        node: None
+#        type: subscriber
+#
+default_pulls:
+#    - gateway: pirate_gateway 
+#    - gateway: pirate_.* 
+   - gateway: gateway1
+     rule:  
+       name: /advertised_chatter_from_gateway1
+       node: None
+       type: publisher
+#    - gateway: pirate_.*
+#      rule:  
+#        name: /chat.*
+#        node: None
+#        type: subscriber
+        

--- a/rocon_gateway_tests/scripts/test_flips.py
+++ b/rocon_gateway_tests/scripts/test_flips.py
@@ -40,7 +40,7 @@ class TestFlips(unittest.TestCase):
         #print("%s" % self.graph._local_gateway)
         self.assertEquals("2", str(len(flipped_interface)))
         for remote_rule in flipped_interface:
-            self.assertEquals("/chatter", remote_rule.rule.name)
+            self.assertEquals("/chatter", remote_rule.remote_rule.rule.name)
             # Should probably assert rule.type and rule.node here as well.
         # Revert state
         try:
@@ -59,7 +59,7 @@ class TestFlips(unittest.TestCase):
             self.fail("Runtime error caught when flipping tutorial connections.")
         flipped_interface = self._wait_for_flipped_interface()
         #print("%s" % self.graph._local_gateway)
-        self.assertIn("/chatter", [remote_rule.rule.name for remote_rule in flipped_interface])
+        self.assertIn("/chatter", [remote_rule.remote_rule.rule.name for remote_rule in flipped_interface])
         try:
             samples.flip_tutorials(cancel=True) 
         except GatewaySampleRuntimeError as e:
@@ -76,7 +76,7 @@ class TestFlips(unittest.TestCase):
             self.fail("Runtime error caught when flipping tutorial connections.")
         flipped_interface = self._wait_for_flipped_interface()
         print("%s" % self.graph._local_gateway)
-        self.assertIn("/chatter", [remote_rule.rule.name for remote_rule in flipped_interface])
+        self.assertIn("/chatter", [remote_rule.remote_rule.rule.name for remote_rule in flipped_interface])
         try:
             samples.flip_tutorials(cancel=True, regex_patterns=True) 
         except GatewaySampleRuntimeError as e:


### PR DESCRIPTION
This PR introduces the following changes
- Flips no longer use pubsubs, but are written in the database. This makes it easier to synchronize flips in intermittent wireless. Furthermore, these flips are encrypted using basic RSA encryption.
- The gateway hub interface no longer blocks listening on a channel.
- Basic RSA encryption/decryption in utils
- Serialization has been switched from json to CPickle, to remove any unicode to string conversion problems. This makes entries in redis slightly less readable.
- There is now an initial lag while flipping, dependent on the watcher thread time period.

Tested using the following script:

```
rocon_launch rocon_gateway_tests singlehub.concert
```
