### PR TITLE
Don't blacklist unresolvable hubs

### DIFF
--- a/rocon_gateway/src/rocon_gateway/gateway_hub.py
+++ b/rocon_gateway/src/rocon_gateway/gateway_hub.py
@@ -183,6 +183,8 @@ class GatewayHub(rocon_hub_client.Hub):
           @type gateway_msgs.RemoteGateway
         '''
         try:
+            # this should probably be posted independently  of whether the hub is contactable or not
+            # refer to https://github.com/robotics-in-concert/rocon_multimaster/pull/273/files#diff-22b726fec736c73a96fd98c957d9de1aL189
             if not statistics.network_info_available:
                 rospy.logdebug("Gateway : unable to publish network statistics [network info unavailable]")
                 return

--- a/rocon_gateway/src/rocon_gateway/hub_manager.py
+++ b/rocon_gateway/src/rocon_gateway/hub_manager.py
@@ -240,7 +240,7 @@ class HubManager(object):
         hub_to_be_disengaged.disconnect()  # necessary to kill failing socket receives
         self._hub_lock.acquire()
         if hub_to_be_disengaged in self.hubs:
-            rospy.loginfo("Gateway : lost connection to the hub [%s][%s]" % (
+            rospy.loginfo("Gateway : disengaged connection with the hub [%s][%s]" % (
                 hub_to_be_disengaged.name, hub_to_be_disengaged.uri))
             self.hubs[:] = [hub for hub in self.hubs if hub != hub_to_be_disengaged]
         self._hub_lock.release()

--- a/rocon_gateway/src/rocon_gateway/network_interface_manager.py
+++ b/rocon_gateway/src/rocon_gateway/network_interface_manager.py
@@ -40,9 +40,8 @@ class NetworkInterfaceManager(object):
           Auto detects the network interface is none is supplied. If one is
           supplied, this function verifies that the interface is connected.
 
-          @return interface_name, interface_type : if detected succesfully,
-                  None, None otherwise
-          @rtype str, int8
+          :returns: the interface name and type if detected successfully
+          :rtype: (str, int8) or None
         '''
 
         interfaces = []
@@ -112,9 +111,7 @@ class NetworkInterfaceManager(object):
                 float(wifi.wireless_info.getBitrate().value)  # Raw bitrate
             _, qual, _, _ = wifi.getStatistics()
         except IOError as e:
-            rospy.logwarn("Looks like the wireless dropped out. I won't " +
-                          "update wireless statistics as the hub can't talk " +
-                          "to me anyway. Error: " + str(e))
+            rospy.logwarn("Gateway : not updating wireless statistics [wireless dropped out][%s]" % str(e))
             return gateway_statistics
 
         gateway_statistics.wireless_link_quality = int(qual.quality)

--- a/rocon_gateway_tests/launch/common/primary_hub.xml
+++ b/rocon_gateway_tests/launch/common/primary_hub.xml
@@ -5,5 +5,6 @@
   <include file="$(find rocon_hub)/launch/hub.launch">
     <arg name="hub_name" value="Primary Hub" />
     <arg name="hub_port" value="6380" />
+    <arg name="gateway_unavailable_timeout" value="10"/>
   </include>
 </launch>

--- a/rocon_hub/src/rocon_hub/watcher.py
+++ b/rocon_hub/src/rocon_hub/watcher.py
@@ -33,8 +33,6 @@ class WatcherThread(threading.Thread):
                 rospy.get_param('~gateway_unavailable_timeout', 30.0)
         self.gateway_dead_timeout = \
                 rospy.get_param('~gateway_dead_timeout', 7200.0)
-        self.gateway_ping_frequency = \
-                rospy.get_param('~gateway_ping_frequency', 0.2)
         self.watcher_thread_rate = rospy.get_param('~watcher_thread_rate', 0.2)
         try:
             self.hub = gateway_hub.GatewayHub(ip, port, [], [])


### PR DESCRIPTION
This fixes #271.

Revert this blacklisting policy. We should keep trying so that gateways that have lost their wireless connection can recover the hub when it comes back in discovery range. Main issue is that avahi hangs on to a `ghost` advertisement of the hub.

@piyushk is this the right way we should handle this? Do you have a better idea?

There are some other minor things in this pull request as well - see the 'Files Changed' view.
