### PR TITLE
Increasing the timeout because of late launching zero conf than gateway

### DIFF
--- a/rocon_hub_client/src/rocon_hub_client/hub_discovery.py
+++ b/rocon_hub_client/src/rocon_hub_client/hub_discovery.py
@@ -264,7 +264,7 @@ def _zeroconf_services_available():
       Check for zeroconf services on startup. If none is found within a suitable
       timeout, disable this module.
     '''
-    zeroconf_timeout = 5  # Amount of time to wait for the zeroconf services to appear
+    zeroconf_timeout = 15  # Amount of time to wait for the zeroconf services to appear
     rospy.loginfo("Gateway : checking if zeroconf services are available...")
     try:
         rospy.wait_for_service("zeroconf/add_listener", timeout=zeroconf_timeout)


### PR DESCRIPTION
When I used the turtlbot as concert client, zeroconf in launched robot was lately launched  than gateway. So, the timeout error often  was happened. 
