### PR TITLE
adding connection_cache resolver.

### DIFF
--- a/rocon_gateway/launch/gateway.launch
+++ b/rocon_gateway/launch/gateway.launch
@@ -15,9 +15,6 @@
   <arg name="gateway_disable_zeroconf" default="false" doc="do not find the hub with zeroconf, make sure you set gateway_hub_uri instead."/>
   <arg name="gateway_custom_rules_file" default="" doc="name of a custom file with gateway rules provided by the user (yaml)."/>
 
-  <arg name="connection_cache_list" default="/rocon/connection_cache/list" doc="topic to listen for connection cache list of connections"/>
-  <arg name="connection_cache_diff" default="/rocon/connection_cache/diff" doc="topic to listen for differences in connection cache list of connections"/>
-
   <group unless="$(arg gateway_disable_zeroconf)">
     <node ns="zeroconf" pkg="zeroconf_avahi" type="zeroconf" name="zeroconf"/>
   </group>
@@ -32,8 +29,5 @@
     <param name="hub_uri" value="$(arg gateway_hub_uri)"/>
     <param name="disable_zeroconf" value="$(arg gateway_disable_zeroconf)"/>
     <param name="custom_rules_file" value="$(arg gateway_custom_rules_file)"/>
-    <!-- remapping subscriber to plug into connection cache -->
-    <remap from="~connections_list" to="$(arg connection_cache_list)"/>
-    <remap from="~connections_diff" to="$(arg connection_cache_diff)"/>
   </node>
 </launch>

--- a/rocon_gateway/scripts/advertise
+++ b/rocon_gateway/scripts/advertise
@@ -97,10 +97,11 @@ def is_in_advertised_list(connection, advertisements):
 
 def resolve_advertisements(gateway_namespace, advertisements):
     master = rocon_gateway.LocalMaster()
-    connection_dictionary = master.get_connection_state()
     connections = []
-    for connection_type in connection_dictionary:
-        connections.extend(connection_dictionary[connection_type])
+    with master.get_connection_state() as connection_dictionary:
+        for connection_type in connection_dictionary:
+            connections.extend(connection_dictionary[connection_type])
+
     connections[:] = [connection for connection in connections if not is_in_advertised_list(connection, advertisements)]
     # some things you should never advertise
     connections[:] = [connection for connection in connections

--- a/rocon_gateway/scripts/flip
+++ b/rocon_gateway/scripts/flip
@@ -156,10 +156,11 @@ def is_in_flipped_connection_list(remote_gateways, connection, flipped_connectio
 
 def resolve_connections(gateway_namespace, remote_gateways, flipped_connections):
     master = rocon_gateway.LocalMaster()
-    connection_dictionary = master.get_connection_state()
     connections = []
-    for connection_type in connection_dictionary:
-        connections.extend(connection_dictionary[connection_type])
+    with master.get_connection_state() as connection_dictionary:
+        for connection_type in connection_dictionary:
+            connections.extend(connection_dictionary[connection_type])
+
     connections[:] = [connection for connection in connections
                       if not is_in_flipped_connection_list(remote_gateways, connection, flipped_connections)]
     # some things you should never flip

--- a/rocon_gateway/src/rocon_gateway/gateway.py
+++ b/rocon_gateway/src/rocon_gateway/gateway.py
@@ -78,17 +78,6 @@ class Gateway(object):
         self.network_interface_manager = NetworkInterfaceManager(self._param['network_interface'])
         # TODO : Use self._param['watch_loop_period'] to set the connection_cache spin freq ( OR directly in connection_cache node ) ?
 
-        self.connections_lock = threading.Lock()
-        self.connections = utils.create_empty_connection_type_dictionary(set)
-        self.connection_cache = rocon_python_comms.ConnectionCacheProxy(
-            list_sub='~connections_list',
-            handle_actions=True,
-            user_callback=self._connection_cache_proxy_cb,
-            diff_opt=True,
-            diff_sub='~connections_diff'
-        )
-        # TODO : REMOVE self.watcher_thread = WatcherThread(self, self._param['watch_loop_period'])
-
     def spin(self):
         if not rospy.core.is_initialized():
             raise rospy.exceptions.ROSInitException("client code must call rospy.init_node() first")
@@ -98,11 +87,10 @@ class Gateway(object):
                 self.update_network_information()
                 remote_gateway_hub_index = self.hub_manager.create_remote_gateway_hub_index()
 
-                self.connections_lock.acquire()
-                self.update_flipped_interface(self.connections, remote_gateway_hub_index)
-                self.update_public_interface(self.connections)
-                self.update_pulled_interface(self.connections, remote_gateway_hub_index)
-                self.connections_lock.release()
+                with self.master.get_connection_state() as connections:
+                    self.update_flipped_interface(connections, remote_gateway_hub_index)
+                    self.update_public_interface(connections)
+                    self.update_pulled_interface(connections, remote_gateway_hub_index)
 
                 registrations = self.hub_manager.get_flip_requests()
                 self.update_flipped_in_interface(registrations, remote_gateway_hub_index)
@@ -110,88 +98,6 @@ class Gateway(object):
         except KeyboardInterrupt:
             rospy.logdebug("keyboard interrupt, shutting down")
             rospy.core.signal_shutdown('keyboard interrupt')
-
-    def _connection_cache_proxy_cb(self, system_state, added_system_state, lost_system_state):
-
-        self.connections_lock.acquire()
-        # if there was no change but we got a callback,
-        # it means it s the first and we need to set the whole list
-        if added_system_state is None and lost_system_state is None:
-            self.connections[gateway_msgs.ConnectionType.ACTION_SERVER] =\
-                utils._get_connections_from_action_chan_dict(
-                        system_state.action_servers, gateway_msgs.ConnectionType.ACTION_SERVER
-                )
-            self.connections[gateway_msgs.ConnectionType.ACTION_CLIENT] =\
-                utils._get_connections_from_action_chan_dict(
-                        system_state.action_clients, gateway_msgs.ConnectionType.ACTION_CLIENT
-                )
-            self.connections[gateway_msgs.ConnectionType.PUBLISHER] =\
-                utils._get_connections_from_pub_sub_chan_dict(
-                        system_state.publishers, gateway_msgs.ConnectionType.PUBLISHER
-                )
-            self.connections[gateway_msgs.ConnectionType.SUBSCRIBER] =\
-                utils._get_connections_from_pub_sub_chan_dict(
-                        system_state.subscribers, gateway_msgs.ConnectionType.SUBSCRIBER
-                )
-            self.connections[gateway_msgs.ConnectionType.SERVICE] =\
-                utils._get_connections_from_service_chan_dict(
-                        system_state.services, gateway_msgs.ConnectionType.SERVICE
-                )
-        else:  # we got some diff, we can optimize
-            # this is not really needed as is ( since the list we get is always updated )
-            # However it is a first step towards an optimized gateway that can work with system state differences
-            new_action_servers = utils._get_connections_from_action_chan_dict(
-                added_system_state.action_servers, gateway_msgs.ConnectionType.ACTION_SERVER
-            )
-            self.connections[gateway_msgs.ConnectionType.ACTION_SERVER] |= new_action_servers
-
-            new_action_clients = utils._get_connections_from_action_chan_dict(
-                added_system_state.action_clients, gateway_msgs.ConnectionType.ACTION_CLIENT
-            )
-            self.connections[gateway_msgs.ConnectionType.ACTION_CLIENT] |= new_action_clients
-
-            new_publishers = utils._get_connections_from_pub_sub_chan_dict(
-                added_system_state.publishers, gateway_msgs.ConnectionType.PUBLISHER
-            )
-            self.connections[gateway_msgs.ConnectionType.PUBLISHER] |= new_publishers
-
-            new_subscribers = utils._get_connections_from_pub_sub_chan_dict(
-                added_system_state.subscribers, gateway_msgs.ConnectionType.SUBSCRIBER
-            )
-            self.connections[gateway_msgs.ConnectionType.SUBSCRIBER] |= new_subscribers
-
-            new_services = utils._get_connections_from_service_chan_dict(
-                added_system_state.services, gateway_msgs.ConnectionType.SERVICE
-            )
-            self.connections[gateway_msgs.ConnectionType.SERVICE] |= new_services
-
-
-            lost_action_servers = utils._get_connections_from_action_chan_dict(
-                lost_system_state.action_servers, gateway_msgs.ConnectionType.ACTION_SERVER
-            )
-            self.connections[gateway_msgs.ConnectionType.ACTION_SERVER] -= lost_action_servers
-
-            lost_action_clients = utils._get_connections_from_action_chan_dict(
-                lost_system_state.action_clients, gateway_msgs.ConnectionType.ACTION_CLIENT
-            )
-            self.connections[gateway_msgs.ConnectionType.ACTION_CLIENT] -= lost_action_clients
-
-            lost_publishers = utils._get_connections_from_pub_sub_chan_dict(
-                lost_system_state.publishers, gateway_msgs.ConnectionType.PUBLISHER
-            )
-            self.connections[gateway_msgs.ConnectionType.PUBLISHER] -= lost_publishers
-
-            lost_subscribers = utils._get_connections_from_pub_sub_chan_dict(
-                lost_system_state.subscribers, gateway_msgs.ConnectionType.SUBSCRIBER
-            )
-            self.connections[gateway_msgs.ConnectionType.SUBSCRIBER] -= lost_subscribers
-
-            lost_services = utils._get_connections_from_service_chan_dict(
-                lost_system_state.services, gateway_msgs.ConnectionType.SERVICE
-            )
-            self.connections[gateway_msgs.ConnectionType.SERVICE] -= lost_services
-
-        self.connections_lock.release()
 
     def shutdown(self):
         for connection_type in utils.connection_types:

--- a/rocon_gateway/src/rocon_gateway/gateway.py
+++ b/rocon_gateway/src/rocon_gateway/gateway.py
@@ -636,10 +636,10 @@ class Gateway(object):
         if response.result == gateway_msgs.ErrorCodes.SUCCESS:
             if not request.cancel:
                 if self.pulled_interface.pull_all(remote_gateway_target_hash_name, request.blacklist):
-                    rospy.loginfo("Gateway : pulling all from gateway '%s'" % (request.gateway))
+                    rospy.loginfo("Gateway : pulling all from gateway [%s]" % (request.gateway))
                 else:
                     response.result = gateway_msgs.ErrorCodes.FLIP_RULE_ALREADY_EXISTS
-                    response.error_message = "already pulling all from gateway '%s' " + request.gateway
+                    response.error_message = "already pulling all from gateway [%s] " % (request.gateway)
             else:  # request.cancel
                 self.pulled_interface.unpull_all(remote_gateway_target_hash_name)
                 rospy.loginfo("Gateway : cancelling a previous pull all request [%s]" % (request.gateway))

--- a/rocon_gateway/src/rocon_gateway/master_api.py
+++ b/rocon_gateway/src/rocon_gateway/master_api.py
@@ -53,13 +53,15 @@ class LocalMaster(rosgraph.Master):
         # in case this class is used directly (script call) we need to find the connection cache
 
         connection_cache_namespace = rocon_gateway_utils.resolve_connection_cache(rospy.Time(5))
+        if not connection_cache_namespace.endswith('/'):
+            connection_cache_namespace += '/'
 
         self.connection_cache = rocon_python_comms.ConnectionCacheProxy(
-            list_sub=connection_cache_namespace + '/connection_cache/list',
+            list_sub=connection_cache_namespace + 'connection_cache/list',
             handle_actions=True,
             user_callback=self._connection_cache_proxy_cb,
             diff_opt=True,
-            diff_sub=connection_cache_namespace + '/connection_cache/diff'
+            diff_sub=connection_cache_namespace + 'connection_cache/diff'
         )
         self.get_system_state = self.connection_cache.getSystemState
 

--- a/rocon_gateway_tests/launch/singlehub/singlehub_gateway1.launch
+++ b/rocon_gateway_tests/launch/singlehub/singlehub_gateway1.launch
@@ -7,9 +7,6 @@
     <rosparam param="firewall">false</rosparam>
     <rosparam param="disable_uuids">true</rosparam>
     <rosparam command="load" file="$(find rocon_gateway_tests)/param/singlehub/gateway1.yaml" />
-    <!-- remapping subscriber to plug into connection cache -->
-    <remap from="~connections_list" to="connection_cache/list"/>
-    <remap from="~connections_diff" to="connection_cache/diff"/>
   </node>
 
   <include file="$(find rocon_gateway_tests)/launch/common/talker.xml">

--- a/rocon_gateway_tests/launch/singlehub/singlehub_gateway2.launch
+++ b/rocon_gateway_tests/launch/singlehub/singlehub_gateway2.launch
@@ -7,9 +7,6 @@
     <rosparam param="firewall">false</rosparam>
     <rosparam param="disable_uuids">true</rosparam>
     <rosparam command="load" file="$(find rocon_gateway_tests)/param/singlehub/gateway2.yaml" />
-    <!-- remapping subscriber to plug into connection cache -->
-    <remap from="~connections_list" to="connection_cache/list"/>
-    <remap from="~connections_diff" to="connection_cache/diff"/>
   </node>
 
   <include file="$(find rocon_gateway_tests)/launch/common/talker.xml">

--- a/rocon_gateway_utils/src/rocon_gateway_utils/resolvers.py
+++ b/rocon_gateway_utils/src/rocon_gateway_utils/resolvers.py
@@ -13,6 +13,7 @@ import rospy
 import gateway_msgs.msg as gateway_msgs
 import rocon_python_comms
 import rosservice
+import rostopic
 
 ##########################################################################
 # Gateway Existence
@@ -20,13 +21,12 @@ import rosservice
 
 
 def resolve_local_gateway(timeout=None):
-    '''
+    """
       @param timeout : timeout on checking for the gateway, if None, it just makes a single attempt.
       @type rospy.rostime.Duration
 
       @raise rocon_python_comms.NotFoundException: if no remote gateways or no matching gateways available.
-    '''
-    #master = rosgraph.Master(rospy.get_name())
+    """
     gateway_namespace = None
     service_names = []
     timeout_time = time.time() + timeout.to_sec() if timeout is not None else None
@@ -51,6 +51,39 @@ def resolve_local_gateway(timeout=None):
             raise rocon_python_comms.NotFoundException("found more than one gateway connected to this master, this is an invalid configuration.")
     #console.debug("Found a local gateway at %s"%gateway_namespace)
     return gateway_namespace
+
+
+def resolve_connection_cache(timeout=None):
+    """
+      @param timeout : timeout on checking for the connection_cache, if None, it just makes a single attempt.
+      @type rospy.rostime.Duration
+
+      @raise rocon_python_comms.NotFoundException: if no connection_cache available.
+    """
+    connection_cache_namespace = None
+    topic_names = []
+    timeout_time = time.time() + timeout.to_sec() if timeout is not None else None
+    while not rospy.is_shutdown():
+        if timeout_time is not None and time.time() > timeout_time:
+            break
+        topic_names = rostopic.find_by_type("rocon_std_msgs/ConnectionsList")
+        if not topic_names or len(topic_names) > 1:
+            connection_cache_namespace = None
+        elif topic_names[0] == '/connection_cache/list':
+            connection_cache_namespace = "/"
+        else:
+            connection_cache_namespace = re.sub(r'/connection_cache/list', '', topic_names[0])
+        if connection_cache_namespace is not None or timeout is None:
+            break
+        else:
+            rospy.rostime.wallsleep(0.1)
+    if not connection_cache_namespace:
+        if not topic_names:
+            raise rocon_python_comms.NotFoundException("no connection_cache found attached to this local master - did you start it?")
+        else:
+            raise rocon_python_comms.NotFoundException("found more than one connection_cache connected to this master, this is an invalid configuration.")
+    #console.debug("Found a connection_cache at %s"%connection_cache_namespace)
+    return connection_cache_namespace
 
 
 def resolve_gateway_info(gateway_namespace=None):


### PR DESCRIPTION
moved connections inside master_api so scripts can have access to them directly.
now gateway discover connection_cache topics. no need to remap -> dropping roslaunch args.
more testing needed.
