### PR TITLE
now looping while waiting for connection cache in gateway's masterapi

### DIFF
--- a/rocon_gateway/src/rocon_gateway/gateway.py
+++ b/rocon_gateway/src/rocon_gateway/gateway.py
@@ -52,7 +52,16 @@ class Gateway(object):
         @param publish_gateway_info_callback : callback for publishing gateway info
         '''
         self.hub_manager = hub_manager
-        self.master = LocalMaster()
+        self.master = None
+        # handling slow startup timeout
+        while self.master is None:
+            try:
+                self.master = LocalMaster()
+            except rocon_python_comms.NotFoundException as exc:
+                rospy.logwarn(str(exc))
+                rospy.logwarn("Retrying...")
+                self.master = None
+
         self.ip = self.master.get_ros_ip()  # gateway is always assumed to sit on the same ip as the master
         self._param = param
         self._unique_name = unique_name

--- a/rocon_gateway/src/rocon_gateway/master_api.py
+++ b/rocon_gateway/src/rocon_gateway/master_api.py
@@ -45,14 +45,16 @@ class LocalMaster(rosgraph.Master):
       been pulled or flipped in from another gateway.
     '''
 
-    def __init__(self):
+    def __init__(self, connection_cache_timeout=None):
         rosgraph.Master.__init__(self, rospy.get_name())
+
+        timeout = connection_cache_timeout or rospy.Time(5)
 
         self.connections_lock = threading.Lock()
         self.connections = utils.create_empty_connection_type_dictionary(set)
         # in case this class is used directly (script call) we need to find the connection cache
 
-        connection_cache_namespace = rocon_gateway_utils.resolve_connection_cache(rospy.Time(5))
+        connection_cache_namespace = rocon_gateway_utils.resolve_connection_cache(timeout)
         if not connection_cache_namespace.endswith('/'):
             connection_cache_namespace += '/'
 


### PR DESCRIPTION
on startup, gateway looping and waiting for connection cache to start, forever.
The gateway script will fail on exception if connection cache not there.
@stonier  If I understood properly that's what we want ?
This only handle the case of connection cache being late when starting up, nothing else.
Ref : https://github.com/robotics-in-concert/rocon_multimaster/pull/331
