### PR TITLE
More robust gateway flip shutdown/connection error handling

### DIFF
--- a/rocon_gateway/src/rocon_gateway/gateway.py
+++ b/rocon_gateway/src/rocon_gateway/gateway.py
@@ -109,15 +109,6 @@ class Gateway(object):
             rospy.logdebug("keyboard interrupt, shutting down")
             rospy.core.signal_shutdown('keyboard interrupt')
 
-    def shutdown(self):
-        for connection_type in utils.connection_types:
-            for flip in self.flipped_interface.flipped[connection_type]:
-                self.hub_manager.send_unflip_request(flip.gateway, flip.rule)
-            for registration in self.flipped_interface.registrations[connection_type]:
-                self.master.unregister(registration)
-            for registration in self.pulled_interface.registrations[connection_type]:
-                self.master.unregister(registration)
-
     def is_connected(self):
         '''
           We often check if we're connected to any hubs often just to ensure we
@@ -373,19 +364,12 @@ class Gateway(object):
                 new_registration = self.master.register(registration)
                 if new_registration is not None:
                     self.flipped_interface.registrations[registration.connection.rule.type].append(new_registration)
-                # Update this flip's status
-                if status != FlipStatus.ACCEPTED:
-                    for hub in remote_gateway_hub_index[registration.remote_gateway]:
-                        if hub.uri not in update_flip_status:
-                            update_flip_status[hub.uri] = []
-                        update_flip_status[hub.uri].append((registration, FlipStatus.ACCEPTED))
-            else:
-                # Just make sure that this flip request is marked as accepted
-                if status != FlipStatus.ACCEPTED:
-                    for hub in remote_gateway_hub_index[registration.remote_gateway]:
-                        if hub.uri not in update_flip_status:
-                            update_flip_status[hub.uri] = []
-                        update_flip_status[hub.uri].append((registration, FlipStatus.ACCEPTED))
+            # Update this flip's status
+            if status != FlipStatus.ACCEPTED:
+                for hub in remote_gateway_hub_index[registration.remote_gateway]:
+                    if hub.uri not in update_flip_status:
+                        update_flip_status[hub.uri] = []
+                    update_flip_status[hub.uri].append((registration, FlipStatus.ACCEPTED))
 
         # Update the flip status for newly added registrations
         for hub_uri, hub in hubs.iteritems():

--- a/rocon_gateway/src/rocon_gateway/gateway_hub.py
+++ b/rocon_gateway/src/rocon_gateway/gateway_hub.py
@@ -252,7 +252,7 @@ class GatewayHub(rocon_hub_client.Hub):
             wireless_noise_level = hub_api.create_rocon_gateway_key(self._unique_gateway_name, 'wireless:noise_level')
             self._redis_server.set(wireless_noise_level, statistics.wireless_noise_level)
         except (redis.exceptions.ConnectionError, redis.exceptions.ResponseError):
-            rospy.logerr("Gateway : unable to publish network statistics [no connection to the hub]")
+            rospy.logdebug("Gateway : unable to publish network statistics [no connection to the hub]")
 
     def unregister_named_gateway(self, gateway_key):
         '''

--- a/rocon_gateway/src/rocon_gateway/ros_parameters.py
+++ b/rocon_gateway/src/rocon_gateway/ros_parameters.py
@@ -82,12 +82,6 @@ def setup_ros_parameters():
     # Network interface name (to be used when there are multiple active interfaces))
     param['network_interface'] = rospy.get_param('~network_interface', '')  # string
 
-    # Let an external party (e.g. concert conductor) manually shutdown the gateway
-    # so we can have control over when flips and pulls get deregistered (lets us do last
-    # minute service calls across masters before our own master goes down)
-    param['external_shutdown'] = rospy.get_param('~external_shutdown', False)
-    param['external_shutdown_timeout'] = rospy.get_param('~external_shutdown_timeout', 15)  # seconds
-
     return param
 
 

--- a/rocon_gateway_tests/launch/common/primary_hub.xml
+++ b/rocon_gateway_tests/launch/common/primary_hub.xml
@@ -5,6 +5,6 @@
   <include file="$(find rocon_hub)/launch/hub.launch">
     <arg name="hub_name" value="Primary Hub" />
     <arg name="hub_port" value="6380" />
-    <arg name="gateway_unavailable_timeout" value="10"/>
+    <arg name="gateway_gone_timeout" value="10"/>
   </include>
 </launch>

--- a/rocon_hub/launch/hub.launch
+++ b/rocon_hub/launch/hub.launch
@@ -2,19 +2,15 @@
   <arg name="hub_name" default="Rocon Hub" />
   <arg name="hub_port" default="6380" />
   <arg name="zeroconf" default="true" />
-  <arg name="gateway_unavailable_timeout" default="30"/>
-  <arg name="gateway_dead_timeout" default="7200"/>
+  <arg name="gateway_gone_timeout" default="30"/>
   <arg name="hub_watcher_thread_rate" default="0.2"/>
-  <arg name="external_shutdown" default="false" /> <!-- useful if you want to do stuff before shutting down the hub in ros' shutdown hooks -->
 
   <node pkg="rocon_hub" type="hub.py" name="hub">
     <rosparam command="load" file="$(find rocon_hub)/param/default.yaml" />
     <param name="name"                        value="$(arg hub_name)" />
     <param name="port"                        value="$(arg hub_port)" />
     <param name="zeroconf"                    value="$(arg zeroconf)" />
-    <param name="external_shutdown"           value="$(arg external_shutdown)" />
-    <param name="gateway_unavailable_timeout" value="$(arg gateway_unavailable_timeout)"/>
-    <param name="gateway_dead_timeout"        value="$(arg gateway_dead_timeout)"/>
+    <param name="gateway_gone_timeout"        value="$(arg gateway_gone_timeout)"/>
     <param name="watcher_thread_rate"         value="$(arg hub_watcher_thread_rate)"/>
   </node>
 </launch>

--- a/rocon_hub/src/rocon_hub/ros_parameters.py
+++ b/rocon_hub/src/rocon_hub/ros_parameters.py
@@ -26,7 +26,5 @@ def load():
     param['port'] = rospy.get_param('~port', '6380')
     param['zeroconf'] = rospy.get_param("~zeroconf", True)
     param['max_memory'] = rospy.get_param('~max_memory', '10mb')
-    param['external_shutdown'] = rospy.get_param('~external_shutdown', False)
-    param['external_shutdown_timeout'] = rospy.get_param('~external_shutdown_timeout', 15.0)
 
     return param

--- a/rocon_hub_client/src/rocon_hub_client/exceptions.py
+++ b/rocon_hub_client/src/rocon_hub_client/exceptions.py
@@ -66,7 +66,8 @@ class HubConnectionLostError(HubError):
         super(HubConnectionLostError, self).__init__(msg)
         self.id = ErrorCodes.HUB_CONNECTION_LOST
 
+
 class HubConnectionFailedError(HubError):
     def __init__(self, msg):
-        super(HubConnectionLostError, self).__init__(msg)
+        super(HubConnectionFailedError, self).__init__(msg)
         self.id = ErrorCodes.HUB_CONNECTION_FAILED

--- a/rocon_hub_client/src/rocon_hub_client/hub_discovery.py
+++ b/rocon_hub_client/src/rocon_hub_client/hub_discovery.py
@@ -27,7 +27,7 @@ class HubDiscovery(threading.Thread):
     '''
       Used to discover hubs via zeroconf.
     '''
-    def __init__(self, external_discovery_update_hook, direct_hub_uri_list=[], disable_zeroconf=False, blacklisted_hubs={}):
+    def __init__(self, verify_connection_hook, direct_hub_uri_list=[], disable_zeroconf=False, blacklisted_hubs={}):
         '''
           :param external_discovery_update: is a callback function that takes action on a discovery
           :type external_discovery_update: GatewayNode.register_gateway(ip, port)
@@ -38,7 +38,7 @@ class HubDiscovery(threading.Thread):
           :type disallowed_hubs: # 'ip:port' : (error_code, error_code_str) dictionary of hubs that have been blacklisted (maintained by manager of this class)
         '''
         threading.Thread.__init__(self)
-        self.discovery_update_hook = external_discovery_update_hook
+        self.verify_connection_hook = verify_connection_hook
         self._trigger_shutdown = False
         self.trigger_update = False
         self._direct_hub_uri_list = direct_hub_uri_list
@@ -60,8 +60,11 @@ class HubDiscovery(threading.Thread):
         '''
           Called from the main program to shutdown this thread.
         '''
+
         self._trigger_shutdown = True
-        self._trigger_update = True  # causes it to interrupt a sleep and drop back to check shutdown condition
+        self.trigger_update = True  # causes it to interrupt a sleep and drop back to check shutdown condition
+
+        # Avoiding local zombies
         if self.is_alive():  # python complains if you join a non-started thread
             self.join()  # wait for the thread to finish
 
@@ -78,8 +81,8 @@ class HubDiscovery(threading.Thread):
         self._last_loop_timestamp = time.time()  # rospy.Time.now()
         # error codes which inform the client is should stop scanning for this hub
         reasons_not_to_keep_scanning = [
-            ErrorCodes.SUCCESS,
-            ErrorCodes.HUB_CONNECTION_ALREADY_EXISTS,
+            # ErrorCodes.SUCCESS,  # success now might still be broken by the otherside => we always need to check
+            # ErrorCodes.HUB_CONNECTION_ALREADY_EXISTS,  # might exist now but not a bit later => always need to check
             ErrorCodes.HUB_CONNECTION_NOT_IN_NONEMPTY_WHITELIST,
             # this now has to be permitted as we will often have zeroconf failing for gateways
             # that have dropped out of wireless range.
@@ -95,7 +98,7 @@ class HubDiscovery(threading.Thread):
                     (ip, port) = _resolve_address(service)
                     service_uri = str(ip) + ':' + str(port)
                     if service_uri not in self._blacklisted_hubs.keys():
-                        result, reason = self.discovery_update_hook(ip, port)
+                        result, reason = self.verify_connection_hook(ip, port)
                         if result == ErrorCodes.HUB_CONNECTION_UNRESOLVABLE:
                             if service_uri not in unresolvable_hub:
                                 rospy.loginfo("Gateway : unresolvable hub [%s]" % reason)
@@ -104,7 +107,6 @@ class HubDiscovery(threading.Thread):
                             rospy.logwarn("Gateway : hub connection failed. [%s][%s]" %(service_uri, reason))
                         elif result == ErrorCodes.SUCCESS:
                             # we're good
-                            rospy.loginfo("Gateway : discovered hub via zeroconf [%s:%s]" % (str(ip), str(port)))
                             if service_uri in unresolvable_hub:
                                 unresolvable_hub.remove(service_uri)
                         else:  # any of the other reasons not to keep scanning
@@ -114,9 +116,9 @@ class HubDiscovery(threading.Thread):
             new_hubs, unused_lost_hubs = self._direct_scan()
             for hub_uri in new_hubs:
                 hostname, port = _resolve_url(hub_uri)
-                rospy.loginfo("Gateway : discovered hub directly [%s]" % hub_uri)
-                result, _ = self.discovery_update_hook(hostname, port)
+                result, _ = self.verify_connection_hook(hostname, port)
                 if result in reasons_not_to_keep_scanning:
+                    rospy.loginfo("Gateway : ignoring discovered hub [%s]" % hub_uri)
                     self._direct_discovered_hubs.append(hub_uri)
             self._discovered_hubs_modification_mutex.release()
             if not self._zeroconf_services_available and not self._direct_hub_uri_list:
@@ -162,8 +164,10 @@ class HubDiscovery(threading.Thread):
     def _direct_scan(self):
         '''
           Ping the list of hubs we are directly looking for to see if they are alive.
+          Also check if the gateway there is listed to determine if the connection should be refreshed
         '''
         discovered_hubs = []
+        already_used_hubs = []
         remove_uris = []
         for uri in self._direct_hub_uri_list:
             (hostname, port) = _resolve_url(uri)


### PR DESCRIPTION
[rocon_gateway] deleting old flips when flipping again, in case.
[rocon_gateway] not unregistering gateway on shutdown to have similar behavior if error
[rocon_hub] simplify gateway unavailable/dead to have only one state "gone"
[rocon_hub_client] small fix to trigger update and exit quickly on shutdown

adding exception handler for registering/unregistering services/topics
fixing launcher to have only one timeout for gateway "gone"
cosmetics

removing external_shutdown special case. simpler shutdown behavior.

improving unavailable -> gone transition. not trying to talk over network when gateway disappear (connection might be down).

now gateway always check its hubs for valid data and can refresh it if needed.

HubConnectionFailedError exception fix.

generous timeout to find connection_cache

fixed behavior when hub disappear. cosmetics.
