### PR TITLE
rename gateway_unavailable to gone

### DIFF
--- a/rocon_hub/param/default.yaml
+++ b/rocon_hub/param/default.yaml
@@ -10,11 +10,11 @@ max_memory: 10mb
 zeroconf: true
 
 ##############################################################################
-# The following are overridable as args if you use the hub roslauncher
+# The following are overridable as args if you use the hub roslauncher 
 ##############################################################################
 
 # Port on which to start the redis server
 port: 6380
 
-# The amount of time to lapse before flagging a gateway as missing.
+# The amount of time to lapse before flagging a gateway as gone.
 gateway_gone_timeout: 30

--- a/rocon_hub/param/default.yaml
+++ b/rocon_hub/param/default.yaml
@@ -10,11 +10,11 @@ max_memory: 10mb
 zeroconf: true
 
 ##############################################################################
-# The following are overridable as args if you use the hub roslauncher 
+# The following are overridable as args if you use the hub roslauncher
 ##############################################################################
 
 # Port on which to start the redis server
 port: 6380
 
 # The amount of time to lapse before flagging a gateway as missing.
-gateway_unavailable_timeout: 30
+gateway_gone_timeout: 30


### PR DESCRIPTION
renames `gateway_unavailable_timeout` to `gateway_gone_timeout`
