### PR TITLE
Remove dir configuration in redis-3.0.conf

### DIFF
--- a/rocon_hub/redis/redis-3.0.conf
+++ b/rocon_hub/redis/redis-3.0.conf
@@ -189,7 +189,7 @@ dbfilename dump.rdb
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir /var/lib/redis
+# dir /var/lib/redis
 
 ################################# REPLICATION #################################
 


### PR DESCRIPTION
- The value is overwritten in local conf anyway

Fixes this issue:
```
[ WARN] Hub : redis-server not found
[ WARN] Hub :     either you can't look up the admin PATH (ok)
[ WARN] Hub :     or it is not installed - hint 'rosdep install rocon_hub'
[INFO] [1545991000.959245]: Hub : version 3.0.6
7137:C 28 Dec 09:56:42.826 # Can't chdir to '/var/lib/redis': Permission denied
[FATAL] Hub : could not connect to the redis server - is it running?
```
Using redis-server 2:3.0.6-1ubuntu0.3 (armhf)